### PR TITLE
Fix up package_data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=[
         'appsettings',
     ],
-    package_data = {'feedback': ['templates/appsettings/*']},
+    package_data = {'appsettings': ['templates/appsettings/*']},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
This fixes an issue where installations created using setup.py do not install
the templates.
